### PR TITLE
feat: Add in-app instructions to PC and Android apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,13 @@ java -jar desktop-app/target/connection-manager-1.0-SNAPSHOT.jar
 
 ### Desktop Application UI
 
-The desktop application has a single screen with a QR code and an input field for an API key.
+The desktop application has a tabbed interface with one tab: "Connection".
 
--   **QR Code**: Scan this QR code with the Half-Hashed Kitty Android app to connect to this desktop application.
--   **API Key**: Enter the API key from the Hashtopolis web interface.
+-   **Connection Tab**: This tab contains all the elements for connecting the Android app and the Hashtopolis server.
+    -   **Instructions**: A label with instructions on how to use the QR code.
+    -   **QR Code**: Scan this QR code with the Half-Hashed Kitty Android app to connect to this desktop application.
+    -   **API Key**: A text field to enter the API key from the Hashtopolis web interface.
+    -   **Save Key Button**: A button to save the API key.
 
 ## Android Application
 
@@ -50,14 +53,37 @@ To build the Android application, you need to have Android Studio installed. Ope
 
 ### Android Application UI
 
-The Android application has a tabbed interface with the following tabs:
+The Android application has a tabbed interface. Here is a description of each tab and its UI elements:
 
--   **Input**: This tab is for providing the input for the hash cracking process. You can either enter the hash directly, or upload a ZIP or PCAPNG file to extract the hash from it.
--   **Attack**: This tab is for starting the hash cracking attack on the remote server.
+-   **Setup**: This tab provides a detailed guide on how to set up a remote hashcat server. This is a crucial first step to use the app.
+-   **PC Connect**: This tab is used to connect to the desktop application. It opens a camera preview to scan the QR code from the PC app.
+-   **Input**: This tab is for providing the input for the hash cracking process.
+    -   **Server URL**: A text field to enter the URL of your remote hashcat server.
+    -   **Enter hash**: A text field to enter the hash you want to crack.
+    -   **Detect Hash**: A button to automatically identify the hash type.
+    -   **Upload Zip**: A button to upload a ZIP file containing a hash.
+    -   **Upload PCAPNG**: A button to upload a PCAPNG file to extract a hash.
+    -   **Hash Mode**: A dropdown to select the hash mode.
+-   **Command Builder**: This tab is for configuring the attack command.
+    -   **Attack Mode**: A dropdown to select the attack mode.
+    -   **Rules File**: A text field for the rules file.
+    -   **Custom Mask**: A text field for a custom mask.
+    -   **Force**: A checkbox to force the attack.
 -   **Wordlist**: This tab is for specifying the path to the wordlist file on the remote server.
+    -   **Remote Wordlist Path**: A text field to enter the path to your wordlist file.
 -   **Mask**: This tab is for creating and selecting masks for hash cracking attacks.
+    -   **Create Mask**: A button to create a new mask.
+    -   **Select Mask File**: A button to select a mask file.
+-   **Attack**: This tab is for starting the hash cracking attack on the remote server.
+    -   **Start Remote Attack**: A button to start the attack.
 -   **Capture**: This tab is for capturing wireless network packets to get the handshake for hash cracking.
--   **Terminal**: This tab shows the raw output from the tools that are being run.
+    -   **Start/Stop Capture**: A button to start or stop the packet capture.
+    -   **Live Output**: A text area that shows the live output from the capture process.
+-   **Terminal**: This tab shows the raw output from the tools that are being run. It provides a terminal-like view of the process.
 -   **Output**: This tab will show the cracked password once it has been found.
 -   **Hashtopolis**: This tab is for connecting to a Hashtopolis server to manage your hash cracking agents.
--   **Pi Control**: This tab is for connecting to a Raspberry Pi that is running the necessary tools.
+    -   **Hashtopolis Server URL**: A text field for the server URL.
+    -   **API Key**: A text field for the API key.
+    -   **Get Agents**: A button to fetch and display the list of agents.
+    -   **Agent List**: A list of agents with their status and last activity.
+-   **Pi Control**: This tab is for connecting to a Raspberry Pi that is running the necessary tools. It opens a camera preview to scan a QR code.

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/MainScreen.kt
@@ -66,7 +66,7 @@ fun MainScreen(
                     "Output" -> OutputTab(viewModel)
                     "Hashtopolis" -> HashtopolisTab(hashtopolisViewModel)
                     "Pi Control" -> PiControlTab(piControlViewModel)
-                    "PC Connect" -> PCConnectionTab()
+                    "PC Connect" -> PCConnectionTab(viewModel)
                 }
                 if (showInstructions) {
                     InstructionsOverlay(selectedId) {

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/screens/ScannerScreen.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/screens/ScannerScreen.kt
@@ -30,7 +30,7 @@ import java.util.concurrent.Executors
 
 @OptIn(ExperimentalGetImage::class)
 @Composable
-fun ScannerScreen(onQrCodeScanned: (String) -> Unit) {
+fun ScannerScreen(instructionText: String, onQrCodeScanned: (String) -> Unit) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val cameraProviderFuture = remember { ProcessCameraProvider.getInstance(context) }
@@ -56,8 +56,11 @@ fun ScannerScreen(onQrCodeScanned: (String) -> Unit) {
         }
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        Text("Scan the QR code from the desktop application to connect.", modifier = Modifier.padding(16.dp))
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text("QR Code Scanner", style = MaterialTheme.typography.headlineSmall)
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(instructionText, style = MaterialTheme.typography.bodyLarge)
+        Spacer(modifier = Modifier.height(16.dp))
         if (hasCameraPermission) {
             AndroidView(
                 factory = { context ->

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/AttackTab.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/AttackTab.kt
@@ -24,5 +24,9 @@ fun AttackTab(viewModel: MainViewModel) {
         Button(onClick = { viewModel.startAttack() }) {
             Text("Start Remote Attack")
         }
+        Text(
+            "This will start the hash cracking attack on the remote server with the configured settings.",
+            style = MaterialTheme.typography.bodySmall
+        )
     }
 }

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/CaptureTab.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/CaptureTab.kt
@@ -41,6 +41,10 @@ fun CaptureTab(viewModel: MainViewModel) {
         ) {
             Text(if (viewModel.isCapturing.value) "Stop Capture" else "Start Capture")
         }
+        Text(
+            "Start or stop capturing wireless network packets. The output will be displayed below.",
+            style = MaterialTheme.typography.bodySmall
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/CommandBuilderTab.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/CommandBuilderTab.kt
@@ -49,28 +49,32 @@ fun CommandBuilderTab(viewModel: MainViewModel) {
                 }
             }
         }
+        Text("Select the hashcat attack mode.", style = MaterialTheme.typography.bodySmall)
+
+        Spacer(modifier = Modifier.height(8.dp))
 
         OutlinedTextField(
             value = viewModel.rulesFile.value,
             onValueChange = { viewModel.rulesFile.value = it },
             label = { Text("Rules File") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp)
+            modifier = Modifier.fillMaxWidth()
         )
+        Text("Specify a rules file for the attack.", style = MaterialTheme.typography.bodySmall)
+
+        Spacer(modifier = Modifier.height(8.dp))
 
         OutlinedTextField(
             value = viewModel.customMask.value,
             onValueChange = { viewModel.customMask.value = it },
             label = { Text("Custom Mask") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp)
+            modifier = Modifier.fillMaxWidth()
         )
+        Text("Enter a custom mask for mask attacks.", style = MaterialTheme.typography.bodySmall)
+
+        Spacer(modifier = Modifier.height(8.dp))
 
         Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(top = 8.dp)
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Checkbox(
                 checked = viewModel.force.value,
@@ -78,5 +82,6 @@ fun CommandBuilderTab(viewModel: MainViewModel) {
             )
             Text("Force")
         }
+        Text("Force the attack, ignoring any warnings.", style = MaterialTheme.typography.bodySmall)
     }
 }

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/HashtopolisTab.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/HashtopolisTab.kt
@@ -14,26 +14,35 @@ import com.hereliesaz.halfhashedkitty.HashtopolisViewModel
 fun HashtopolisTab(viewModel: HashtopolisViewModel) {
     Column(modifier = Modifier.padding(16.dp)) {
         Text("This tab is for connecting to a Hashtopolis server to manage your hash cracking agents.")
+
+        Spacer(modifier = Modifier.height(16.dp))
+
         OutlinedTextField(
             value = viewModel.serverUrl.value,
             onValueChange = { viewModel.serverUrl.value = it },
             label = { Text("Hashtopolis Server URL") },
             modifier = Modifier.fillMaxWidth()
         )
+        Text("The URL of your Hashtopolis server.", style = MaterialTheme.typography.bodySmall)
+
+        Spacer(modifier = Modifier.height(8.dp))
+
         OutlinedTextField(
             value = viewModel.apiKey.value,
             onValueChange = { viewModel.apiKey.value = it },
             label = { Text("API Key") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp)
+            modifier = Modifier.fillMaxWidth()
         )
+        Text("Your Hashtopolis API key.", style = MaterialTheme.typography.bodySmall)
+
+        Spacer(modifier = Modifier.height(8.dp))
+
         Button(
-            onClick = { viewModel.getAgents() },
-            modifier = Modifier.padding(top = 8.dp)
+            onClick = { viewModel.getAgents() }
         ) {
             Text("Get Agents")
         }
+        Text("Fetch and display the list of agents from the server.", style = MaterialTheme.typography.bodySmall)
         viewModel.errorMessage.value?.let { errorMsg ->
             Text(
                 text = errorMsg,

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/InputTab.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/InputTab.kt
@@ -40,24 +40,31 @@ fun InputTab(viewModel: MainViewModel) {
 
     Column(modifier = Modifier.padding(16.dp)) {
         Text("This tab is for providing the input for the hash cracking process. You can either enter the hash directly, or upload a ZIP or PCAPNG file to extract the hash from it.")
+
+        Spacer(modifier = Modifier.height(16.dp))
+
         OutlinedTextField(
             value = viewModel.serverUrl.value,
             onValueChange = { viewModel.serverUrl.value = it },
             label = { Text("Server URL") },
             modifier = Modifier.fillMaxWidth()
         )
+        Text("The URL of your remote hashcat server.", style = MaterialTheme.typography.bodySmall)
+
+        Spacer(modifier = Modifier.height(8.dp))
+
         OutlinedTextField(
             value = viewModel.hashToCrack.value,
             onValueChange = { viewModel.hashToCrack.value = it },
             label = { Text("Enter hash") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp)
+            modifier = Modifier.fillMaxWidth()
         )
+        Text("The hash you want to crack.", style = MaterialTheme.typography.bodySmall)
+
+        Spacer(modifier = Modifier.height(8.dp))
+
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp)
+            modifier = Modifier.fillMaxWidth()
         ) {
             OutlinedButton(
                 onClick = { viewModel.identifyHash() },
@@ -70,8 +77,7 @@ fun InputTab(viewModel: MainViewModel) {
             }
             OutlinedButton(
                 onClick = { zipLauncher.launch("application/zip") },
-                modifier = Modifier
-                    .weight(1f),
+                modifier = Modifier.weight(1f),
                 shape = RoundedCornerShape(0.dp)
             ) {
                 Text("Upload Zip")
@@ -86,9 +92,11 @@ fun InputTab(viewModel: MainViewModel) {
                 Text("Upload PCAPNG")
             }
         }
+        Text("Use these buttons to detect the hash type, or upload a file containing the hash.", style = MaterialTheme.typography.bodySmall)
 
+        Spacer(modifier = Modifier.height(8.dp))
 
-        Box(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+        Box(modifier = Modifier.fillMaxWidth()) {
             OutlinedTextField(
                 value = viewModel.selectedHashMode.value?.name ?: "Select Hash Mode",
                 onValueChange = {},
@@ -119,5 +127,6 @@ fun InputTab(viewModel: MainViewModel) {
                 }
             }
         }
+        Text("Select the hash mode for the cracking session.", style = MaterialTheme.typography.bodySmall)
     }
 }

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/MaskTab.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/MaskTab.kt
@@ -20,11 +20,19 @@ fun MaskTab() {
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text("This tab is for creating and selecting masks for hash cracking attacks.")
+
+        Spacer(modifier = Modifier.height(16.dp))
+
         Button(onClick = { /* TODO: Implement mask creator */ }) {
             Text("Create Mask")
         }
+        Text("Create a new mask for mask attacks.", style = MaterialTheme.typography.bodySmall)
+
+        Spacer(modifier = Modifier.height(8.dp))
+
         Button(onClick = { /* TODO: Implement file picker */ }) {
             Text("Select Mask File")
         }
+        Text("Select a mask file from your device.", style = MaterialTheme.typography.bodySmall)
     }
 }

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/OutputTab.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/OutputTab.kt
@@ -20,12 +20,13 @@ fun OutputTab(viewModel: MainViewModel) {
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text("This tab will show the cracked password once it has been found.")
+        Text("This tab will show the cracked password once it has been found.", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(16.dp))
         if (viewModel.crackedPassword.value != null) {
             Text("Password Found!", fontWeight = FontWeight.Bold)
             Text(viewModel.crackedPassword.value!!)
         } else {
-            Text("No password found yet.")
+            Text("No password found yet. Check the Terminal tab for progress.")
         }
     }
 }

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/PCConnectionTab.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/PCConnectionTab.kt
@@ -1,18 +1,15 @@
 package com.hereliesaz.halfhashedkitty.ui.tabs
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import com.hereliesaz.halfhashedkitty.MainViewModel
+import com.hereliesaz.halfhashedkitty.ui.screens.ScannerScreen
 
 @Composable
-fun PCConnectionTab() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Text("PC Connection Screen")
-    }
+fun PCConnectionTab(viewModel: MainViewModel) {
+    ScannerScreen(
+        instructionText = "Scan the QR code from the desktop application to connect.",
+        onQrCodeScanned = { qrCodeValue ->
+            viewModel.onQrCodeScanned(qrCodeValue)
+        }
+    )
 }

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/PiControlTab.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/PiControlTab.kt
@@ -6,7 +6,10 @@ import com.hereliesaz.halfhashedkitty.ui.screens.ScannerScreen
 
 @Composable
 fun PiControlTab(piControlViewModel: PiControlViewModel) {
-    ScannerScreen(onQrCodeScanned = { qrCodeValue ->
-        piControlViewModel.onQrCodeScanned(qrCodeValue)
-    })
+    ScannerScreen(
+        instructionText = "Scan the QR code from your Raspberry Pi to connect.",
+        onQrCodeScanned = { qrCodeValue ->
+            piControlViewModel.onQrCodeScanned(qrCodeValue)
+        }
+    )
 }

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/SetupTab.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/SetupTab.kt
@@ -23,12 +23,25 @@ fun SetupTab() {
             .padding(16.dp)
             .verticalScroll(scrollState)
     ) {
-        Text("Remote Hashcat Server Setup Guide", fontWeight = FontWeight.Bold)
+        Text("Remote Hashcat Server Setup Guide", style = MaterialTheme.typography.headlineSmall)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text("Introduction", style = MaterialTheme.typography.titleLarge)
+        Divider(modifier = Modifier.padding(vertical = 8.dp))
         Text(
             """
             To use this app, you need to set up a remote server with hashcat installed.
             This server will listen for requests from the app and run the hashcat commands.
+            """.trimIndent()
+        )
 
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text("Server Requirements", style = MaterialTheme.typography.titleLarge)
+        Divider(modifier = Modifier.padding(vertical = 8.dp))
+        Text(
+            """
             1. Install hashcat:
                Follow the official instructions to install hashcat on your server.
                https://hashcat.net/hashcat/
@@ -36,11 +49,15 @@ fun SetupTab() {
             2. Install Python and Flask:
                You will need Python 3 and the Flask web framework.
                pip install Flask
-
-            3. Create the server script:
-               Create a file named `server.py` with the following content:
             """.trimIndent()
         )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text("Server Script", style = MaterialTheme.typography.titleLarge)
+        Divider(modifier = Modifier.padding(vertical = 8.dp))
+        Text("Create a file named `server.py` with the following content:")
+        Spacer(modifier = Modifier.height(8.dp))
         Text(
             """
             from flask import Flask, request, jsonify
@@ -77,13 +94,19 @@ fun SetupTab() {
             modifier = Modifier
                 .background(Color.LightGray)
                 .padding(8.dp)
+                .fillMaxWidth()
         )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text("Running and Configuration", style = MaterialTheme.typography.titleLarge)
+        Divider(modifier = Modifier.padding(vertical = 8.dp))
         Text(
             """
-            4. Run the server:
+            1. Run the server:
                python server.py
 
-            5. Configure the app:
+            2. Configure the app:
                Enter your server's URL in the "Input" tab of the app.
                Make sure your server is accessible from your phone (e.g., on the same Wi-Fi network, or port-forwarded).
             """.trimIndent()

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/TerminalTab.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/TerminalTab.kt
@@ -1,12 +1,11 @@
 package com.hereliesaz.halfhashedkitty.ui.tabs
 
 import androidx.compose.foundation.background
-<<<<<<< HEAD
 import androidx.compose.foundation.layout.Box
-=======
 import androidx.compose.foundation.layout.Column
->>>>>>> origin/feature/build-pc-app
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -21,18 +20,22 @@ import com.hereliesaz.halfhashedkitty.MainViewModel
 
 @Composable
 fun TerminalTab(viewModel: MainViewModel) {
-<<<<<<< HEAD
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black)
-            .padding(16.dp),
-        contentAlignment = Alignment.Center
-    ) {
-        if (viewModel.terminalOutput.isEmpty()) {
-            Text("Terminal is not active.", color = Color.Gray)
-        } else {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.padding(16.dp).fillMaxSize()) {
+        Text("This tab shows the raw output from the tools that are being run. It is useful for monitoring the progress of the attack.")
+        Spacer(modifier = Modifier.height(16.dp))
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .padding(16.dp)
+        ) {
+            if (viewModel.terminalOutput.isEmpty()) {
+                item {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("Terminal is not active.", color = Color.Gray)
+                    }
+                }
+            } else {
                 items(viewModel.terminalOutput) { line ->
                     Text(
                         text = line,
@@ -40,22 +43,6 @@ fun TerminalTab(viewModel: MainViewModel) {
                         fontFamily = FontFamily.Monospace
                     )
                 }
-=======
-    Column(modifier = Modifier.padding(16.dp).fillMaxSize()) {
-        Text("This tab shows the raw output from the tools that are being run.")
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Color.Black)
-                .padding(16.dp)
-        ) {
-            items(viewModel.terminalOutput) { line ->
-                Text(
-                    text = line,
-                    color = Color.White,
-                    fontFamily = FontFamily.Monospace
-                )
->>>>>>> origin/feature/build-pc-app
             }
         }
     }

--- a/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/WordlistTab.kt
+++ b/app/src/main/java/com/hereliesaz/halfhashedkitty/ui/tabs/WordlistTab.kt
@@ -22,11 +22,15 @@ fun WordlistTab(viewModel: MainViewModel) {
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text("This tab is for specifying the path to the wordlist file on the remote server.")
+
+        Spacer(modifier = Modifier.height(16.dp))
+
         OutlinedTextField(
             value = viewModel.wordlistPath.value,
             onValueChange = { viewModel.wordlistPath.value = it },
             label = { Text("Remote Wordlist Path") },
             modifier = Modifier.fillMaxWidth()
         )
+        Text("The full path to the wordlist file on the remote server.", style = MaterialTheme.typography.bodySmall)
     }
 }

--- a/desktop-app/src/main/java/com/hereliesaz/connectionmanager/ui/ConnectionPanel.java
+++ b/desktop-app/src/main/java/com/hereliesaz/connectionmanager/ui/ConnectionPanel.java
@@ -19,43 +19,75 @@ public class ConnectionPanel extends JPanel {
     private String apiKey;
 
     public ConnectionPanel(String connectionString) {
-        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(5, 5, 5, 5);
+        gbc.gridwidth = 1;
 
         // Instructions
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.anchor = GridBagConstraints.CENTER;
         JLabel instructionsLabel = new JLabel("Scan this QR code with the Half-Hashed Kitty Android app to connect to this desktop application.");
-        instructionsLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
-        add(instructionsLabel);
+        add(instructionsLabel, gbc);
 
         // QR Code
+        gbc.gridy = 1;
+        gbc.weighty = 1.0;
+        gbc.anchor = GridBagConstraints.CENTER;
         try {
             BufferedImage qrImage = generateQrCode(connectionString);
             JLabel qrLabel = new JLabel(new ImageIcon(qrImage));
-            qrLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
-            add(qrLabel);
+            add(qrLabel, gbc);
         } catch (WriterException | IOException e) {
             e.printStackTrace();
-            add(new JLabel("Error generating QR code."));
+            add(new JLabel("Error generating QR code."), gbc);
         }
+        gbc.weighty = 0.0;
 
-        // API Key Input
-        JLabel apiKeyLabel = new JLabel("Enter the API key from the Hashtopolis web interface.");
-        apiKeyLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
-        add(apiKeyLabel);
+        // Input Panel
+        gbc.gridy = 2;
+        gbc.anchor = GridBagConstraints.CENTER;
+        add(createInputPanel(), gbc);
+    }
 
-        JPanel apiKeyPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
-        apiKeyPanel.add(new JLabel("API Key:"));
+    private JPanel createInputPanel() {
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(2, 2, 2, 2);
+        gbc.anchor = GridBagConstraints.WEST;
+
+        // API Key
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        panel.add(new JLabel("API Key:"), gbc);
+
+        gbc.gridx = 1;
         apiKeyField = new JTextField(30);
-        apiKeyPanel.add(apiKeyField);
-        JButton saveButton = new JButton("Save Key");
-        apiKeyPanel.add(saveButton);
+        panel.add(apiKeyField, gbc);
 
-        add(Box.createRigidArea(new Dimension(0, 10)));
-        add(apiKeyPanel);
+        gbc.gridy = 1;
+        JLabel apiKeyInstruction = new JLabel("Enter the API key from your Hashtopolis web interface.");
+        apiKeyInstruction.setFont(apiKeyInstruction.getFont().deriveFont(10f));
+        panel.add(apiKeyInstruction, gbc);
+
+        // Save Button
+        gbc.gridx = 1;
+        gbc.gridy = 2;
+        JButton saveButton = new JButton("Save Key");
+        panel.add(saveButton, gbc);
+
+        gbc.gridy = 3;
+        JLabel saveButtonInstruction = new JLabel("Click to save the API key.");
+        saveButtonInstruction.setFont(saveButtonInstruction.getFont().deriveFont(10f));
+        panel.add(saveButtonInstruction, gbc);
 
         saveButton.addActionListener(e -> {
             this.apiKey = apiKeyField.getText();
             JOptionPane.showMessageDialog(this, "API Key Saved!");
         });
+
+        return panel;
     }
 
     public String getApiKey() {


### PR DESCRIPTION
This change adds instructional text directly into the UI of both the PC and Android applications, as requested by the user.

For the PC app, this involved refactoring the layout to use GridBagLayout and adding JLabels with instructions.

For the Android app, this involved adding Text composables with instructions to each tab.

## Summary by Sourcery

Add in-app instructional text to both desktop and Android applications by refactoring the desktop layout, injecting descriptive labels across Compose tabs and screens, and updating documentation.

New Features:
- Add instructional labels and guidance in the desktop ConnectionPanel UI
- Introduce descriptive instructional text and spacing in Android Compose tabs and ScannerScreen

Enhancements:
- Refactor desktop ConnectionPanel layout to GridBagLayout and consolidate API key input
- Extend ScannerScreen to accept customizable instruction text parameter

Documentation:
- Update README to reflect new in-app instructions for desktop and Android interfaces